### PR TITLE
add good first issue link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@
 
 Any documentation team member is able to pick up issues opened by contributors. 
 
+Is this your first time here to contribute? Great! We're so glad you are here! You can find a list of "good first issues" [here](https://github.com/WordPress/Documentation-Issue-Tracker/labels/good%20first%20issue).
+
 Whether you pick up an issue to work on or are simply implementing the changes suggested by someone else, please make sure you do the following
 
 1. Label the issues accordingly

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Thank you for taking the time to report an issue.
 
 ## Resolving Issues
 
-Any documentation team member is able to pick up issues opened by contributors. 
+Any documentation team member is able to pick up issues opened by contributors.
+
+Is this your first time here to contribute? Great! We're so glad you are here! You can find a list of "good first issues" [here](https://github.com/WordPress/Documentation-Issue-Tracker/labels/good%20first%20issue).
 
 Whether you pick up an issue to work on or are simply implementing the changes suggested by someone else, please make sure you do the following
 


### PR DESCRIPTION
This PR resolves https://github.com/WordPress/Documentation-Issue-Tracker/issues/365 by adding a couple lines to the README.md and CONTRIBUTING.md files.