### PR TITLE
Add clarification for Recovery Mode Email instructions

### DIFF
--- a/recovery-mode-improvement.md
+++ b/recovery-mode-improvement.md
@@ -1,0 +1,10 @@
+# Recovery Mode Email Clarification
+
+When WordPress encounters a fatal error, it sends a Recovery Mode email to the site administrator.  
+This email includes a special login link that allows access to the site's dashboard in Recovery Mode.
+
+**Important Points:**
+- Recovery Mode links are valid for 24 hours.
+- The email is sent to the admin email address configured in WordPress Settings.
+- If the email is not received, users should check spam folders or contact their hosting provider.
+- Recovery Mode allows administrators to deactivate problematic plugins or themes.


### PR DESCRIPTION
This pull request adds a new markdown file explaining and clarifying Recovery Mode Email instructions for end users.  
Fixes WordPress/Documentation-Issue-Tracker#740