### PR TITLE
Update issue reporting instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ All other Make / WordPress team handbooks are maintained by internally by said r
 
 ## How to report an issue?
 
+**Before opening a new issue**, please search the **[existing issues](https://github.com/WordPress/Documentation-Issue-Tracker/issues)** to check whether the problem has already been reported.
+
 At the top of this GitHub repository is an Issues tab, click on that tab. The next page will show a green button for "New issue" in the top right, click there to start an issue filling out the template as complete as possible. See [GitHub's official documentation for issues](https://docs.github.com/en/issues).
 
 Thank you for taking the time to report an issue.


### PR DESCRIPTION
Added a note to search existing issues before reporting.

Related to this issue: https://github.com/WordPress/Documentation-Issue-Tracker/issues/1914